### PR TITLE
Add babel plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/node_modules
+node_modules
 /npm-debug.log
-/package-lock.json
+package-lock.json
 /.vscode
 /bundl.config.js

--- a/plugins/bundl-plugin-babel/LICENSE
+++ b/plugins/bundl-plugin-babel/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Vimlet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/plugins/bundl-plugin-babel/README.md
+++ b/plugins/bundl-plugin-babel/README.md
@@ -1,0 +1,50 @@
+# bundl-plugin-babel
+
+Bundl plugin to compile code using Babel.
+
+## Installation
+
+```sh
+# npm
+npm i -D bundl-plugin-babel
+# yarn
+yarn add -D bundl-plugin-babel
+```
+
+## Usage
+
+### With `babel.config.js`
+
+```js
+const babel = require('bundl-plugin-babel') 
+
+module.exports = {
+  output: {
+    'build/bundle.js': {
+      use: babel,
+      input: {
+        'src/**.js': true
+      }
+    }
+  }
+}
+```
+
+### Custom options
+
+```js
+const babel = require('bundl-plugin-babel') 
+
+module.exports = {
+  output: {
+    'build/bundle.js': {
+      use: entry => babel(entry, {
+        presets: ['@babel/preset-env']
+      }),
+      input: {
+        'src/**.js': true
+      }
+    }
+  }
+}
+```

--- a/plugins/bundl-plugin-babel/index.js
+++ b/plugins/bundl-plugin-babel/index.js
@@ -1,0 +1,6 @@
+const { transformAsync } = require('@babel/core')
+
+module.exports = async (entry, opts) => {
+  entry.content = (await transformAsync(entry.content, opts)).code
+  return entry
+}

--- a/plugins/bundl-plugin-babel/package.json
+++ b/plugins/bundl-plugin-babel/package.json
@@ -4,7 +4,7 @@
   "description": "Babel plugin for Bundl",
   "main": "index.js",
   "keywords": ["bundl", "babel", "bundl-plugin"],
-  "author": "",
+  "author": "talentlessguy <pilll.PL22@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
     "@vimlet/bundl": "^1.0.4"

--- a/plugins/bundl-plugin-babel/package.json
+++ b/plugins/bundl-plugin-babel/package.json
@@ -3,15 +3,19 @@
   "version": "1.0.0",
   "description": "Babel plugin for Bundl",
   "main": "index.js",
-  "keywords": ["bundl", "babel", "bundl-plugin"],
+  "keywords": [
+    "bundl",
+    "babel",
+    "bundl-plugin"
+  ],
   "author": "talentlessguy <pilll.PL22@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@vimlet/bundl": "^1.0.4"
+    "@vimlet/bundl": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@vimlet/bundl": "^1.0.4"
+    "@vimlet/bundl": "latest"
   },
   "dependencies": {}
 }

--- a/plugins/bundl-plugin-babel/package.json
+++ b/plugins/bundl-plugin-babel/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bundl-plugin-babel",
+  "version": "1.0.0",
+  "description": "Babel plugin for Bundl",
+  "main": "index.js",
+  "keywords": ["bundl", "babel", "bundl-plugin"],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "@vimlet/bundl": "^1.0.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.5.5",
+    "@vimlet/bundl": "^1.0.4"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
I created a small plugin using Bundl and Babel. It can be used like this:

```js
const babel = require('bundl-plugin-babel')

module.exports = {
  output: {
    'build/bundle.js': {
      use: babel,
      input: {
        'src/**.js': true
      }
    }
  }
}
```

Babel automatically detects config but in case you need some custom options you can pass them as a second argument:

```js
const babel = require('bundl-plugin-babel')

module.exports = {
  output: {
    'build/bundle.js': {
      use: entry => babel(entry, { presets: [require('@babel/preset-env')] }),
      input: {
        'src/**.js': true
      }
    }
  }
}
```